### PR TITLE
Toggle between singular and plural form of status bar restore text

### DIFF
--- a/src/PackmanVsix/PackageService.cs
+++ b/src/PackmanVsix/PackageService.cs
@@ -66,7 +66,8 @@ namespace PackmanVsix
                         }
                     }
 
-                    VSPackage.DTE.StatusBar.Text = $"{manifest.Packages.Count} libraries successfully installed";
+                    var libraryText = (manifest.Packages.Count == 1) ? "library" : "libraries";
+                    VSPackage.DTE.StatusBar.Text = $"{manifest.Packages.Count} {libraryText} successfully installed";
                 }
                 else
                 {


### PR DESCRIPTION
When only 1 library is restored, the singular form of the "library" text should appear in the status bar of VS.