### PR TITLE
Replace package.json references with packman.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ files to your project.
 
 ### Restoring packages
 It's very easy to restore libraries. Just right-click the
-package.json manifest file and select
+packman.json manifest file and select
 **Restore packages**.
 
 ![Package restore](art/context-menu-restore.png)

--- a/src/PackmanVsix/Options.cs
+++ b/src/PackmanVsix/Options.cs
@@ -14,7 +14,7 @@ namespace PackmanVsix
 
         [DisplayName("Restore packages on save")]
         [Category("Package install")]
-        [Description("Automatically restore packages when saving package.json.")]
+        [Description("Automatically restore packages when saving packman.json.")]
         [DefaultValue(true)]
         public bool RestoreOnSave { get; set; } = true;
 


### PR DESCRIPTION
Fix a mistake in `README.md` and in the **Tools** --> **Options** --> **Web** --> **Client Side Library Installer** dialog.